### PR TITLE
Update branding icon

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ description: "Restores your .NET Core local tools"
 author: "xt0rted"
 
 branding:
-  icon: "tool"
+  icon: "download"
   color: "purple"
 
 runs:


### PR DESCRIPTION
The `tool` icon isn't on the allowed list so had to pick a different one.